### PR TITLE
Fix: #80. Remove localhost from #/servers.

### DIFF
--- a/apiv1/tests/vocabularies/test_api_base.yaml
+++ b/apiv1/tests/vocabularies/test_api_base.yaml
@@ -39,7 +39,7 @@ testcases:
         - id: A00
           label: Item A00
           uri: "https://example.com/vocabularies/test/A00"
-          href: "https://schema.gov.it/api/vocabularies/v1/istat/ateco-2025/A00"
+          href: "https://schema.gov.it/api/vocabularies/v1/vocabularies/istat/ateco-2025/A00"
 
 - name: get_vocabularies
   description: |-
@@ -62,9 +62,9 @@ testcases:
             count: 1, item: [{about: "https://w3id.org/italia/stat/controlled-vocabulary/economy/ateco-2025",
                 author: "https://w3id.org/italia/data/public-organization/ISTAT",
 
-                href: "https://schema.gov.it/api/vocabularies/v1//vocabularies/istat/ateco-2025",
+                href: "https://schema.gov.it/api/vocabularies/v1/vocabularies/istat/ateco-2025",
                 hreflang: [it], predecessor-version: [{href: "https://old.example.com/istat/ateco-2025"}],
-                service-desc: [{href: "https://schema.gov.it/api/vocabularies/v1//vocabularies/istat/ateco-2025/openapi.yaml",
+                service-desc: [{href: "https://schema.gov.it/api/vocabularies/v1/vocabularies/istat/ateco-2025/openapi.yaml",
                     type: application/openapi+yaml}], service-meta: [
                   {href: "https://w3id.org/italia/stat/controlled-vocabulary/economy/ateco-2025?output=application/ld+json",
                     type: application/ld+json}], title: Ateco

--- a/apiv1/vocabularies/catalog.py
+++ b/apiv1/vocabularies/catalog.py
@@ -135,7 +135,7 @@ def _list_vocabularies_impl(
         if (
             item := _to_catalog_item(
                 dict(x),
-                request.state.api_base_url,
+                request.state.api_base_url.rstrip("/"),
                 request.state.predecessor_base_url,
             )
         )

--- a/apiv1/vocabularies/data.py
+++ b/apiv1/vocabularies/data.py
@@ -123,7 +123,12 @@ async def show_items(
     items = items[:limit]
 
     api_url = "/".join(
-        [request.state.api_base_url.rstrip("/"), agencyId, keyConcept]
+        [
+            request.state.api_base_url.rstrip("/"),
+            "vocabularies",
+            agencyId,
+            keyConcept,
+        ]
     )
     response = {
         "limit": limit,
@@ -261,11 +266,11 @@ async def show_vocabulary_spec(
         spec = copy.deepcopy(request.state.base_spec)
         spec["info"] = vocabulary_oas["info"]
         spec["components"]["schemas"]["Item"] = item_oas
-        spec.setdefault("servers", []).append(
+        spec["servers"] = [
             {
                 "url": f"{request.state.api_base_url}/vocabularies/{agencyId}/{keyConcept}/"
             }
-        )
+        ]
 
         # Remove all paths that don't start with /vocabularies/{agencyId}/{keyConcept}
         # In the others, replace that prefix with "/"


### PR DESCRIPTION
## This PR

- [x] Ensures that the generated openapi.yaml file does not reference localhost, but only the exposed URL.
- [x] Fix missing path `/vocabularies` in hrefs. 